### PR TITLE
Don't clone root node as this doesn't work with inline sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = postcss.plugin('postcss-chunk', function (opts) {
 
 		function nextChunk() {
 			count = 0;
-			chunk = css.clone({nodes: []});
+			chunk = postcss.root();
 			chunks.push(chunk);
 		}
 


### PR DESCRIPTION
Cloning a PreviousMap isn't supported by postcss, this results in:

```
[TypeError: Cannot read property 'match' of undefined]
    at PreviousMap.loadAnnotation (/home/niko/www/postcss-chunk-test/node_modules/postcss/lib/previous-map.js:52:13)
    at new PreviousMap (/home/niko/www/postcss-chunk-test/node_modules/postcss/lib/previous-map.js:27:14)
    at new Input (/home/niko/www/postcss-chunk-test/node_modules/postcss/lib/input.js:39:19)
    at Object.parse [as default] (/home/niko/www/postcss-chunk-test/node_modules/postcss/lib/parse.js:17:17)
    at new LazyResult (/home/niko/www/postcss-chunk-test/node_modules/postcss/lib/lazy-result.js:54:42)
    at Processor.process (/home/niko/www/postcss-chunk-test/node_modules/postcss/lib/processor.js:30:16)
    at Object.<anonymous> (/home/niko/www/postcss-chunk-test/test.js:7:6)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
```

As an alternative create a new empty root node, I don't think any data is lost in doing that.

Properties like semicolon or after are lost, but they are not worth keeping when creating chunks.
